### PR TITLE
recipes(pkgs.esp-clang): init at 21.1.3_20260408

### DIFF
--- a/recipes/pkgs/esp/esp-clang/recipe.nix
+++ b/recipes/pkgs/esp/esp-clang/recipe.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  pkgs.esp-clang = {
+    version = "21.1.3_20260408";
+    description = "ESP-Clang toolchain for Espressif SoCs.";
+    homePage = "https://github.com/espressif/llvm-project";
+    mainProgram = "clang";
+    license = lib.licenses.asl20;
+
+    source = {
+      url =
+        "https://github.com/espressif/llvm-project/releases/download/esp-21.1.3_20260408/"
+        + "clang-esp-21.1.3_20260408-x86_64-linux-gnu.tar.xz";
+      hash = "sha256-bmK/GXO1e1OIqtKBzhRj6VPnCz2N9070Zoxw8x++2mM=";
+    };
+
+    build.standardBuilder = {
+      enable = true;
+      packages.build = lib.optional pkgs.stdenv.isLinux pkgs.autoPatchelfHook;
+      packages.run = [
+        pkgs.libxml2
+        pkgs.libz
+        pkgs.stdenv.cc.cc.lib
+      ];
+    };
+
+    build.extraAttrs = {
+      dontBuild = true;
+
+      installPhase = ''
+        mkdir -p $out
+        cp -a . $out/
+      '';
+    };
+
+    test.script = ''
+      clang --version | grep "Espressif clang"
+      xtensa-esp32-elf-clang-as --version
+      riscv32-esp-elf-clang-as --version
+    '';
+  };
+}

--- a/recipes/pkgs/esp/esp-clang/recipe.nix
+++ b/recipes/pkgs/esp/esp-clang/recipe.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+
+{
+  pkgs.esp-clang = {
+    version = "21.1.3_20260408";
+    description = "ESP-Clang toolchain for Espressif SoCs.";
+    homePage = "https://github.com/espressif/llvm-project";
+    mainProgram = "clang";
+    license = lib.licenses.asl20;
+
+    source = {
+      url = "https://github.com/espressif/llvm-project/releases/download/esp-${config.pkgs.esp-clang.version}/clang-esp-${config.pkgs.esp-clang.version}-x86_64-linux-gnu.tar.xz";
+      hash = "sha256-bmK/GXO1e1OIqtKBzhRj6VPnCz2N9070Zoxw8x++2mM=";
+    };
+
+    build.standardBuilder = {
+      enable = true;
+      packages.build = lib.optionals pkgs.stdenv.isLinux [ pkgs.autoPatchelfHook ];
+      packages.run = [
+        pkgs.libxml2
+        pkgs.libz
+        pkgs.stdenv.cc.cc.lib
+      ];
+    };
+
+    build.extraAttrs = {
+      dontBuild = true;
+
+      installPhase = ''
+        mkdir -p $out
+        cp -a . $out/
+      '';
+    };
+
+    test.script = ''
+      clang --version | grep "Espressif clang"
+      xtensa-esp32-elf-clang-as --version
+      riscv32-esp-elf-clang-as --version
+    '';
+  };
+}


### PR DESCRIPTION
## Summary

This PR adds a new `esp-clang` package to NGI Forge.

The package provides the prebuilt Espressif LLVM/Clang toolchain for Linux (`x86_64`), including the compiler and related LLVM utilities required for Espressif development.

## Features

- Packages the official Espressif LLVM toolchain release.
- Installs the complete toolchain into the Nix store.
- Uses `autoPatchelfHook` to ensure Linux binaries are usable.
- Exposes the `clang` executable and target-specific tools (Xtensa and RISC-V).

## Motivation

This package is the first step toward packaging the Espressif development ecosystem in NGI Forge. It will serve as a dependency for future packages such as:

- `esp-idf`
- `esp-openocd`
- `esptool`
- `esp32-open-mac`

## Testing

Verified that the package builds successfully:

```bash
nix build .#pkgs.esp-clang
```


### SUB-ISSUE OF https://github.com/ngi-nix/forge/issues/639
