### PR TITLE
fix(apps.labplot): remove xvfb-run to bypass Xvfb segfaults on buildbot

### DIFF
--- a/recipes/apps/labplot/recipe.nix
+++ b/recipes/apps/labplot/recipe.nix
@@ -43,12 +43,10 @@ in
     };
 
     test.programs = {
-      packages = [ pkgs.xvfb-run ];
       script = ''
         export LC_ALL=C.UTF-8
         export LANG=C.UTF-8
-        export QT_QPA_PLATFORM=offscreen
-        xvfb-run labplot --help-all | grep -q "LabPlot"
+        labplot -platform offscreen --help-all | grep -q "LabPlot"
       '';
     };
   };

--- a/recipes/pkgs/labplot/recipe.nix
+++ b/recipes/pkgs/labplot/recipe.nix
@@ -111,12 +111,10 @@ in
     };
 
     test = {
-      packages = [ pkgs.xvfb-run ];
       script = ''
         export LC_ALL=C.UTF-8
         export LANG=C.UTF-8
-        export QT_QPA_PLATFORM=offscreen
-        xvfb-run labplot --help-all | grep -q "LabPlot"
+        labplot -platform offscreen --help-all | grep -q "LabPlot"
       '';
     };
   };


### PR DESCRIPTION
This is required to unblock all other prs to forge to be merged.

Fixes https://buildbot.ngi.nixos.org/#/builders/1764/builds/304

I tried to understand why this test is flaky, but it is not clear the root cause of it, so I remove xvfb-run which is problematic when running labplot. (other uses of xvfb-run in other recipes don't hit this issue)
