### PR TITLE
recipes(pkgs.esp-clang): fix isLinux

### DIFF
--- a/recipes/pkgs/esp/esp-clang/recipe.nix
+++ b/recipes/pkgs/esp/esp-clang/recipe.nix
@@ -20,7 +20,7 @@
 
     build.standardBuilder = {
       enable = true;
-      packages.build = lib.optionals pkgs.stdenv.isLinux [ pkgs.autoPatchelfHook ];
+      packages.build = lib.optionals pkgs.stdenv.hostPlatform.isLinux [ pkgs.autoPatchelfHook ];
       packages.run = [
         pkgs.libxml2
         pkgs.libz


### PR DESCRIPTION
```
evaluation warning: stdenv.isLinux is deprecated, use
stdenv.hostPlatform.isLinux instead
```