### PR TITLE
fix(ui): allow markdown links to reference local links

### DIFF
--- a/flake/develop/commands/dev/dev-ui-config/generate.py
+++ b/flake/develop/commands/dev/dev-ui-config/generate.py
@@ -21,11 +21,7 @@ def generate_grants():
 
 
 def generate_pkg_recipe(name, index, is_test_pkg=False):
-    description = (
-        f"[Markdown Link Test](https://example.com) {fake.sentence()}"
-        if is_test_pkg
-        else fake.sentence()
-    )
+    description = fake.sentence()
     return f"""{{
   config,
   lib,
@@ -75,7 +71,7 @@ def generate_app_recipe(name, index, is_test_app=False):
 {{
 apps."{name}" = {{
   description = "{fake.sentence()}";
-  usage = "{fake.text()}";
+  usage = "{fake.text()}\n\n[project documentation](https://example.com)\n\n[enter the Nix shell](app/mock-test#run-shell)";
 
   links = {{
     website = "{fake.url()}";

--- a/ui/src/Main/Helpers/Markdown.elm
+++ b/ui/src/Main/Helpers/Markdown.elm
@@ -89,24 +89,33 @@ renderer =
                 block |> codeBlock
         , link =
             \link content ->
+                let
+                    isExternal =
+                        String.startsWith "http" link.destination
+
+                    baseAttrs =
+                        if isExternal then
+                            [ Html.Attributes.target "_blank"
+                            , Html.Attributes.rel "noopener"
+                            ]
+
+                        else
+                            []
+
+                    linkAttrs =
+                        Html.Attributes.href link.destination
+                            :: onClickStopPropagation
+                            :: baseAttrs
+                in
                 case link.title of
                     Just title ->
                         Html.a
-                            [ Html.Attributes.href link.destination
-                            , Html.Attributes.title title
-                            , Html.Attributes.target "_blank"
-                            , Html.Attributes.rel "noopener"
-                            , onClickStopPropagation
-                            ]
+                            (Html.Attributes.title title :: linkAttrs)
                             content
 
                     Nothing ->
                         Html.a
-                            [ Html.Attributes.href link.destination
-                            , Html.Attributes.target "_blank"
-                            , Html.Attributes.rel "noopener"
-                            , onClickStopPropagation
-                            ]
+                            linkAttrs
                             content
         , orderedList =
             \startingIndex items ->

--- a/ui/tests/e2e/specs/components/markdown.spec.ts
+++ b/ui/tests/e2e/specs/components/markdown.spec.ts
@@ -1,44 +1,51 @@
 import { expect, test } from "@playwright/test";
-import { TEST_PKG_SEARCH } from "../constants";
+import { TEST_APP_NAME, TEST_APP_SEARCH } from "../constants";
 
 test.describe("Markdown Rendering", () => {
   test.beforeEach(async ({ page }) => {
     const responsePromise = page.waitForResponse((response) => response.url().includes("forge-config.json"));
-    await page.goto("./pkgs");
+    await page.goto("./apps");
     await responsePromise;
   });
 
   test("markdown links open in a new tab without triggering parent card click", async ({ page, context }) => {
     const searchBar = page.getByTestId("main-search-bar");
-    await searchBar.fill(TEST_PKG_SEARCH);
+    await searchBar.fill(TEST_APP_SEARCH);
 
-    const testPackage = page.locator(`[data-testid="pkg-result"][id="mock-test-pkg"]`);
-    await expect(testPackage).toBeVisible();
+    const testApp = page.locator(`[data-testid="app-result"]:has([data-app-name="${TEST_APP_NAME}"])`).first();
+    await expect(testApp).toBeVisible();
 
-    const pkgUrl = page.url();
+    // Click the app card to go to the details page
+    await testApp.click();
+    await expect(page).toHaveURL(new RegExp(`.*app\\/${TEST_APP_NAME}`));
 
-    // Look for the markdown link inside the package card
-    const markdownLink = testPackage.locator(".markdown-content a").first();
-    await expect(markdownLink).toBeVisible();
+    const appUrl = page.url();
 
-    // The link should have target="_blank"
-    await expect(markdownLink).toHaveAttribute("target", "_blank");
+    const externalLink = page.locator(".markdown-content a:has-text(\"project documentation\")").first();
+    await expect(externalLink).toBeVisible();
 
-    // Click the link and wait for the new page event
+    await expect(externalLink).toHaveAttribute("target", "_blank");
+
     const [newPage] = await Promise.all([
       context.waitForEvent("page"),
-      markdownLink.click(),
+      externalLink.click(),
     ]);
 
     await newPage.waitForLoadState();
 
-    // Verify the new page URL is correct (example.com from the generator)
-    expect(newPage.url()).toContain("example.com");
-
-    // Verify that clicking the link did NOT trigger the package card's routing
-    // If bubbling was not prevented, the URL would change to /pkgs#mock-test-pkg
-    expect(page.url()).toBe(pkgUrl);
+    expect(newPage.url()).not.toBe(appUrl);
+    expect(page.url()).toBe(appUrl);
 
     await newPage.close();
+
+    const internalLink = page.locator(".markdown-content a:has-text(\"enter the Nix shell\")").first();
+    await expect(internalLink).toBeVisible();
+
+    await expect(internalLink).not.toHaveAttribute("target", "_blank");
+
+    await internalLink.click();
+
+    const expectedUrl = new RegExp(`.*app\\/${TEST_APP_NAME}#run-shell`);
+    await expect(page).toHaveURL(expectedUrl);
   });
 });

--- a/ui/tests/e2e/specs/constants.ts
+++ b/ui/tests/e2e/specs/constants.ts
@@ -1,9 +1,9 @@
 export const BASE_URL = process.env.BASE_URL || "http://127.0.0.1:3000";
-const isProd = BASE_URL.includes("netlify.app") || BASE_URL.includes("github.io");
+const isProd = BASE_URL.includes("netlify.app") || BASE_URL.includes("github.io") || process.env.UI_CMD == "forge-ui";
 
-export const TEST_APP_NAME = process.env.TEST_APP_NAME || (isProd ? "hello-web" : "mock-test");
-export const TEST_PKG_NAME = process.env.TEST_PKG_NAME || (isProd ? "hello-web" : "mock-test-package");
-export const TEST_APP_SEARCH = process.env.TEST_APP_SEARCH || (isProd ? "hello-web" : "mock-test");
-export const TEST_PKG_SEARCH = process.env.TEST_PKG_SEARCH || (isProd ? "hello-web" : "mock-test");
+export const TEST_APP_NAME = process.env.TEST_APP_NAME || (isProd ? "emerge" : "mock-test");
+export const TEST_PKG_NAME = process.env.TEST_PKG_NAME || (isProd ? "emerge" : "mock-test-pkg");
+export const TEST_APP_SEARCH = process.env.TEST_APP_SEARCH || (isProd ? "emerge" : "mock-test");
+export const TEST_PKG_SEARCH = process.env.TEST_PKG_SEARCH || (isProd ? "emerge" : "mock-test");
 
 export const TEST_RECIPE_OPTION = process.env.TEST_RECIPE_OPTION || "apps.<name>.description";


### PR DESCRIPTION
Previously when implementing opening markdown links in new tab, I forgot about this use case.

Check for eg. Emerge usage instructions.