### PR TITLE
treewide: ocamlBuilder.scope -> ocamlBuilder.ocamlPackages

### DIFF
--- a/forge/modules/builders/ocaml-builder/default.nix
+++ b/forge/modules/builders/ocaml-builder/default.nix
@@ -11,7 +11,7 @@
     (packageBuilderModule {
       name = "ocamlBuilder";
       imports = ./options.nix;
-      mkDerivation = (config.build.ocamlBuilder.scope pkgs).buildDunePackage;
+      mkDerivation = (config.build.ocamlBuilder.ocamlPackages pkgs).buildDunePackage;
       attrs =
         builder: finalAttrs: previousAttrs:
         {

--- a/forge/modules/builders/ocaml-builder/options.nix
+++ b/forge/modules/builders/ocaml-builder/options.nix
@@ -18,7 +18,7 @@
       [Nixpkgs OCaml documentation](https://nixos.org/manual/nixpkgs/unstable/#sec-language-ocaml)
     '';
 
-    scope = lib.mkOption {
+    ocamlPackages = lib.mkOption {
       type = lib.types.functionTo lib.types.attrs;
       default = pkgs: pkgs.ocaml-ng.ocamlPackages;
       defaultText = lib.literalExpression "pkgs: pkgs.ocaml-ng.ocamlPackages";
@@ -38,7 +38,7 @@
       description = ''
         Minimal OCaml version required to build the package.
 
-        The build fails early with an explicit message when `scope` provides an
+        The build fails early with an explicit message when `ocamlPackages` provides an
         older compiler.
 
         Mapped to `minimalOCamlVersion`.

--- a/recipes/pkgs/ocaml-quic/recipe.nix
+++ b/recipes/pkgs/ocaml-quic/recipe.nix
@@ -43,7 +43,7 @@ in
     build.ocamlBuilder = {
       enable = true;
 
-      scope = _: ocamlPackages;
+      ocamlPackages = _: ocamlPackages;
 
       packages = {
         build = [ pkgs.pkg-config ];


### PR DESCRIPTION
follow up https://github.com/ngi-nix/forge/pull/880#issuecomment-5330086911

https://github.com/ngi-nix/forge/pull/642

since there's only one call site, i'm directly naming this instead of going with the make rename option