### PR TITLE
Don't run nix flake check in github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,17 +27,6 @@ jobs:
       # - name: Get more storage space
       #   uses: wimpysworld/nothing-but-nix@main
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
-
-      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
-        with:
-          name: ngi-forge
-          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-
-      - name: Run checks
-        run: nix flake check --keep-going --accept-flake-config --max-jobs 1 --option sandbox relaxed
-
   lint:
     name: Run format checks
     runs-on: ubuntu-latest


### PR DESCRIPTION
We already do so in buildbot on makemake.