### PR TITLE
fix(ci): mark git-pages-cli as executable

### DIFF
--- a/.github/workflows/git-pages-deploy.yml
+++ b/.github/workflows/git-pages-deploy.yml
@@ -67,6 +67,8 @@ jobs:
           PREVIEW_URL_BASE="${PREVIEW_URL}/pr-${PR_NUMBER}"
           COMMIT_URL_BASE="${PREVIEW_URL}/${PR_REV}"
 
+          chmod +x ./git-pages-cli
+
           # make each preview expire in 100 days
           ./git-pages-cli "$COMMIT_URL_BASE" --upload-dir deploy_dist_commit --expires 100
           ./git-pages-cli "$PREVIEW_URL_BASE" --upload-dir deploy_dist_pr --expires 100

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,7 +136,6 @@ jobs:
         run: |
           nix build --inputs-from . nixpkgs#pkgsStatic.git-pages-cli -o gpc-result
           cp gpc-result/bin/git-pages-cli ./git-pages-cli
-          chmod +x ./git-pages-cli
 
       - name: Upload preview UI
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
This should've worked ideally but github's download-artifact might be stripping
executable bits?
