### PR TITLE
build: add composable dev shells; init minimal, ui & ci 

### DIFF
--- a/flake/develop/default.nix
+++ b/flake/develop/default.nix
@@ -10,6 +10,7 @@
 
     let
       formatter = pkgs.callPackage ./formatter.nix { inputs = forge-inputs; };
+
       devShell = pkgs.callPackage ./devshell.nix {
         inputs = forge-inputs;
         inherit formatter;
@@ -26,36 +27,92 @@
         pyPkgs.sphinx-notfound-page
       ]);
 
-      devPkgs = [
-        pkgs.dive
-        pkgs.elmPackages.elm
-        pkgs.elmPackages.elm-language-server
-        pkgs.elmPackages.elm-review
-        pkgs.elmPackages.elm-test
-        pkgs.elmPackages.elm-test-rs
-        pkgs.esbuild
-        pkgs.gnumake
-        pkgs.json-diff
-        pkgs.nixfmt
-        pkgs.nodejs
-        pkgs.playwright-test
-        pkgs.podman-compose
-        pkgs.systemd-manager-tui
-        pkgs.watchman
-        forge-inputs.self.legacyPackages.${system}.elm-watch
-        forge-inputs.self.legacyPackages.${system}.elm2nix
-        sphinxEnv
+      devPkgs = {
+        tools = [
+          pkgs.json-diff
+          pkgs.nixfmt
+        ];
+
+        ui = [
+          pkgs.elmPackages.elm
+          pkgs.elmPackages.elm-language-server
+          pkgs.elmPackages.elm-review
+          pkgs.elmPackages.elm-test
+          pkgs.elmPackages.elm-test-rs
+          pkgs.esbuild
+          pkgs.nodejs
+          pkgs.watchman
+          forge-inputs.self.legacyPackages.${system}.elm-watch
+        ];
+
+        ui-test = [
+          pkgs.playwright-test
+        ];
+
+        dev = [
+          pkgs.dive
+          pkgs.podman-compose
+          pkgs.systemd-manager-tui
+          forge-inputs.self.legacyPackages.${system}.elm2nix
+        ];
+
+        docs = [
+          sphinxEnv
+          pkgs.gnumake
+        ];
+      };
+
+      allDevPkgs = lib.pipe devPkgs [
+        (lib.mapAttrsToList (_: v: v))
+        (lib.flatten)
       ];
+
+      filterCommands =
+        excludeNames: lib.filter (cmd: !(lib.elem (cmd.package.name or cmd.name) excludeNames));
+
+      mkDevShell =
+        {
+          fromShell ? devShell,
+          packages,
+          excludeCommands ? [ ],
+        }:
+
+        fromShell.extend (
+          final: prev: {
+            packages = filterCommands excludeCommands (prev.packages ++ packages);
+            defaultCmds = filterCommands excludeCommands prev.defaultCmds;
+            formatters = filterCommands excludeCommands prev.formatters;
+          }
+        );
+
+      devShells = {
+        default = mkDevShell {
+          packages = allDevPkgs;
+        };
+
+        minimal = mkDevShell {
+          packages = devPkgs.tools;
+          excludeCommands = [
+            "forge-update"
+            "test-ui"
+            "treefmt"
+          ];
+        };
+
+        ui = mkDevShell {
+          fromShell = devShells.minimal;
+          packages = devPkgs.ui;
+        };
+
+        ci = mkDevShell {
+          fromShell = devShells.minimal;
+          packages = with devPkgs; ui ++ ui-test;
+        };
+      };
     in
 
     {
       formatter = formatter.package;
-
-      devShells.default =
-        (devShell.extend (
-          final: prev: {
-            packages = prev.packages ++ devPkgs;
-          }
-        )).finalPackage;
+      devShells = lib.mapAttrs (_: shell: shell.finalPackage) devShells;
     };
 }

--- a/flake/develop/devshell.nix
+++ b/flake/develop/devshell.nix
@@ -41,7 +41,7 @@ let
 
     mapCommands =
       category: packages:
-      builtins.map (p: {
+      map (p: {
         inherit category;
         package = p;
       }) packages;
@@ -61,7 +61,7 @@ let
         lib.filterAttrs (
           name: value:
           # filter only the valid args for devshell.eval
-          builtins.elem name [
+          lib.elem name [
             "name"
             "motd"
             "commands"
@@ -151,12 +151,12 @@ let
           else
             baseNameOf parentDir;
 
-        groupedFiles = builtins.groupBy getCategory files;
+        groupedFiles = lib.groupBy getCategory files;
       in
       lib.concatLists (
         lib.mapAttrsToList (
           category: categoryFiles:
-          final.mapCommands category (builtins.map (path: callPackage' path { }) categoryFiles)
+          final.mapCommands category (map (path: callPackage' path { }) categoryFiles)
         ) groupedFiles
       );
   });


### PR DESCRIPTION
Thanks to this, building what we need becomes faster and less resource-intensive. For example, the `ui` devShell (~1.02 GiB) is almost 500% smaller than the `default` one (~6.11 GiB).

```shellSession
nix run .#devShells.x86_64-linux.ui -- forge-ui
```