### PR TITLE
+packager@simplicity(ocamlBuilder): only `buildDunePackage` is actually used

### DIFF
--- a/forge/modules/builders/ocaml-builder/default.nix
+++ b/forge/modules/builders/ocaml-builder/default.nix
@@ -15,7 +15,7 @@
       attrs =
         builder: finalAttrs: previousAttrs:
         {
-          propagatedBuildInputs = builder.packages.dependencies;
+          propagatedBuildInputs = previousAttrs.propagatedBuildInputs or [ ] ++ builder.packages.dependencies;
 
           env = (previousAttrs.env or { }) // {
             DUNE_CACHE = "disabled";

--- a/forge/modules/builders/ocaml-builder/default.nix
+++ b/forge/modules/builders/ocaml-builder/default.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  pkgs,
   packageBuilderModule,
   ...
 }:
@@ -11,7 +10,7 @@
     (packageBuilderModule {
       name = "ocamlBuilder";
       imports = ./options.nix;
-      mkDerivation = (config.build.ocamlBuilder.ocamlPackages pkgs).buildDunePackage;
+      mkDerivation = config.build.ocamlBuilder.buildDunePackage;
       attrs =
         builder: finalAttrs: previousAttrs:
         {

--- a/forge/modules/builders/ocaml-builder/options.nix
+++ b/forge/modules/builders/ocaml-builder/options.nix
@@ -3,6 +3,7 @@
 
 {
   lib,
+  pkgs,
   ...
 }:
 
@@ -18,18 +19,18 @@
       [Nixpkgs OCaml documentation](https://nixos.org/manual/nixpkgs/unstable/#sec-language-ocaml)
     '';
 
-    ocamlPackages = lib.mkOption {
-      type = lib.types.functionTo lib.types.attrs;
-      default = pkgs: pkgs.ocaml-ng.ocamlPackages;
-      defaultText = lib.literalExpression "pkgs: pkgs.ocaml-ng.ocamlPackages";
+    buildDunePackage = lib.mkOption {
+      type = with lib.types; functionTo package;
+      default = pkgs.ocaml-ng.ocamlPackages.buildDunePackage;
+      defaultText = lib.literalExpression "pkgs.ocaml-ng.ocamlPackages.buildDunePackage";
       description = ''
-        The OCaml package scope providing the builder and the dependencies.
+        The OCaml package builder.
 
-        Override to build against a different OCaml compiler version. All
-        dependencies must be taken from the same scope, otherwise they are
-        compiled for an incompatible compiler version.
+        Override to build against a different OCaml compiler version.
+        All dependencies must be taken from the same scope,
+        otherwise they are compiled for an incompatible compiler version.
       '';
-      example = lib.literalExpression "pkgs: pkgs.ocaml-ng.ocamlPackages_latest";
+      example = lib.literalExpression "pkgs.ocaml-ng.ocamlPackages_latest.buildDunePackage";
     };
 
     minimalVersion = lib.mkOption {

--- a/recipes/pkgs/ocaml-quic/recipe.nix
+++ b/recipes/pkgs/ocaml-quic/recipe.nix
@@ -43,8 +43,6 @@ in
     build.ocamlBuilder = {
       enable = true;
 
-      ocamlPackages = _: ocamlPackages;
-
       packages = {
         build = [ pkgs.pkg-config ];
 


### PR DESCRIPTION
AFAICS (but @stepbrobd may prove me wrong) `build.ocamlBuilder.ocamlPackages`:
- is not used so far;
- is a function, likely because some `ocamlPackages` are broken;
- is a function given `pkgs` without obvious need;
- is no needed because ocaml packages belong in `build.ocamlBuilder.packages.dependencies`.