### PR TITLE
feat(pkgs): introduce test runner option; recipes(pkgs.prismafs): use nixos test runner

### DIFF
--- a/forge/modules/builders/shared/default.nix
+++ b/forge/modules/builders/shared/default.nix
@@ -111,11 +111,31 @@
                   nativeCheckInputs = builder.packages.check;
 
                   passthru = {
-                    test = pkgs.testers.runCommand {
-                      name = "${finalAttrs.pname}-test";
-                      buildInputs = [ finalAttrs.finalPackage ] ++ config.test.packages;
-                      script = config.test.script + "\ntouch $out";
-                    };
+                    test =
+                      let
+                        runner = {
+                          bash = pkgs.testers.runCommand {
+                            name = "${finalAttrs.pname}-test";
+                            buildInputs = [ finalAttrs.finalPackage ] ++ config.test.packages;
+                            script = config.test.script + "\ntouch $out";
+                          };
+
+                          nixos = pkgs.testers.runNixOSTest {
+                            name = "${finalAttrs.pname}-test";
+                            nodes.machine = {
+                              imports = [ config.test.nixosConfig ];
+                              environment.systemPackages = [ finalAttrs.finalPackage ] ++ config.test.packages;
+                              system.stateVersion = "25.11";
+                            };
+                            testScript = ''
+                              machine.start()
+                              machine.wait_for_unit("multi-user.target")
+                              machine.succeed("${pkgs.writeShellScript "${finalAttrs.pname}-test" config.test.script}")
+                            '';
+                          };
+                        };
+                      in
+                      runner.${config.test.runner};
 
                     env = pkgs.mkShell {
                       dontBuild = true;

--- a/forge/modules/builders/shared/default.nix
+++ b/forge/modules/builders/shared/default.nix
@@ -111,31 +111,7 @@
                   nativeCheckInputs = builder.packages.check;
 
                   passthru = {
-                    test =
-                      let
-                        runner = {
-                          bash = pkgs.testers.runCommand {
-                            name = "${finalAttrs.pname}-test";
-                            buildInputs = [ finalAttrs.finalPackage ] ++ config.test.packages;
-                            script = config.test.script + "\ntouch $out";
-                          };
-
-                          nixos = pkgs.testers.runNixOSTest {
-                            name = "${finalAttrs.pname}-test";
-                            nodes.machine = {
-                              imports = [ config.test.nixosConfig ];
-                              environment.systemPackages = [ finalAttrs.finalPackage ] ++ config.test.packages;
-                              system.stateVersion = "25.11";
-                            };
-                            testScript = ''
-                              machine.start()
-                              machine.wait_for_unit("multi-user.target")
-                              machine.succeed("${pkgs.writeShellScript "${finalAttrs.pname}-test" config.test.script}")
-                            '';
-                          };
-                        };
-                      in
-                      runner.${config.test.runner};
+                    test = config.test.derivation { inherit pkgs finalAttrs; };
 
                     env = pkgs.mkShell {
                       dontBuild = true;

--- a/forge/modules/pkgs/pkg.nix
+++ b/forge/modules/pkgs/pkg.nix
@@ -235,32 +235,10 @@
     };
 
     # Test configuration
-    test = {
-      packages = lib.mkOption {
-        type = lib.types.listOf lib.types.package;
-        default = [ ];
-        description = "List of packages available in the test script.";
-        example = lib.literalExpression "[ pkgs.curl pkgs.jq ]";
-      };
-      script = lib.mkOption {
-        type = lib.types.str;
-        default = ''
-          echo "Test script"
-        '';
-        description = ''
-          Script to test the package.
-          The package being tested is available in PATH.
-
-          Launch test with:
-
-          ```
-          nix build .#pkgs.''${package}.test
-          ```
-        '';
-        example = ''
-          hello | grep "Hello, world"
-        '';
-      };
+    test = lib.mkOption {
+      type = lib.types.submodule ./test.nix;
+      default = { };
+      description = "Test configuration";
     };
 
     # Development configuration

--- a/forge/modules/pkgs/test.nix
+++ b/forge/modules/pkgs/test.nix
@@ -1,4 +1,5 @@
 {
+  config,
   lib,
   ...
 }:
@@ -41,6 +42,45 @@
         When using the `nixos` VM runner, you can pass extra configurations
         using the `test.nixosModules` option.
       '';
+    };
+    derivation = lib.mkOption {
+      internal = true;
+      description = "Function that builds the test derivation according to runner.";
+      type = lib.types.functionTo lib.types.package;
+      default =
+        {
+          pkgs,
+          finalAttrs,
+          ...
+        }:
+
+        let
+          name = "${finalAttrs.pname}-test";
+          packages = [ finalAttrs.finalPackage ] ++ config.packages;
+        in
+
+        if config.runner == "bash" then
+          pkgs.testers.runCommand {
+            inherit name;
+            buildInputs = packages;
+            script = config.script + "\ntouch $out";
+          }
+        else if config.runner == "nixos" then
+          pkgs.testers.runNixOSTest {
+            inherit name;
+            nodes.machine = {
+              imports = [ config.nixosConfig ];
+              environment.systemPackages = packages;
+              system.stateVersion = "25.11";
+            };
+            testScript = ''
+              machine.start()
+              machine.wait_for_unit("multi-user.target")
+              machine.succeed("${pkgs.writeShellScript "${finalAttrs.pname}-test" config.script}")
+            '';
+          }
+        else
+          throw "Unsupported test runner: ${config.runner}";
     };
     nixosConfig = lib.mkOption {
       type = lib.types.deferredModule;

--- a/forge/modules/pkgs/test.nix
+++ b/forge/modules/pkgs/test.nix
@@ -29,5 +29,34 @@
         hello | grep "Hello, world"
       '';
     };
+    runner = lib.mkOption {
+      type = lib.types.enum [
+        "bash"
+        "nixos"
+      ];
+      default = "bash";
+      description = ''
+        Type of runner to execute the script.
+
+        When using the `nixos` VM runner, you can pass extra configurations
+        using the `test.nixosModules` option.
+      '';
+    };
+    nixosConfig = lib.mkOption {
+      type = lib.types.deferredModule;
+      default = { };
+      description = ''
+        Extra configuration passed to the NixOS VM running the test.
+
+        See the list of available
+        [NixOS options](https://search.nixos.org/options) .
+      '';
+      example = lib.literalExpression ''
+        {
+          virtualisation.memorySize = 4096;
+          virtualisation.diskSize = 10240;
+        }
+      '';
+    };
   };
 }

--- a/forge/modules/pkgs/test.nix
+++ b/forge/modules/pkgs/test.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  ...
+}:
+{
+  options = {
+    packages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      description = "List of packages available in the test script.";
+      example = lib.literalExpression "[ pkgs.curl pkgs.jq ]";
+    };
+    script = lib.mkOption {
+      type = lib.types.str;
+      default = ''
+        echo "Test script"
+      '';
+      description = ''
+        Script to test the package.
+        The package being tested is available in PATH.
+
+        Launch test with:
+
+        ```
+        nix build .#pkgs.''${package}.test
+        ```
+      '';
+      example = ''
+        hello | grep "Hello, world"
+      '';
+    };
+  };
+}

--- a/recipes/pkgs/prismafs/recipe.nix
+++ b/recipes/pkgs/prismafs/recipe.nix
@@ -40,45 +40,31 @@ in
         rm -rf prismafs 
       '';
       installFlags = [ "PREFIX=$(out)" ];
-
-      passthru.tests.nixos = pkgs.testers.runNixOSTest {
-        name = "prismafs-nixos";
-
-        nodes.machine = {
-          environment.systemPackages = [ recipe.result.derivation ];
-          boot.kernelModules = [ "fuse" ];
-        };
-
-        testScript = ''
-          machine.wait_for_unit("multi-user.target")
-
-          machine.succeed("""
-            # see: https://github.com/goranb131/prismaFS/blob/main/test-script.sh
-            BASE=$(mktemp -d)
-            SESSION=$(mktemp -d)
-            MNT=$(mktemp -d)
-            CONF=$(mktemp)
-
-            echo "base $BASE" > $CONF
-            echo "session $SESSION" >> $CONF
-            echo "hello" > $BASE/testfile.txt
-
-            prismafs -c $CONF $MNT
-            sleep 0.5
-
-            ls $MNT | grep testfile.txt
-            cat $MNT/testfile.txt | grep hello
-            cat $MNT/dev/cpu
-
-            umount $MNT
-          """)
-        '';
-      };
-
     };
 
-    test.script = ''
-      prismafs -v | grep -q ${recipe.version}
-    '';
+    test = {
+      script = ''
+        # see: https://github.com/goranb131/prismaFS/blob/main/test-script.sh
+        BASE=$(mktemp -d)
+        SESSION=$(mktemp -d)
+        MNT=$(mktemp -d)
+        CONF=$(mktemp)
+
+        echo "base $BASE" > $CONF
+        echo "session $SESSION" >> $CONF
+        echo "hello" > $BASE/testfile.txt
+
+        prismafs -c $CONF $MNT
+        sleep 0.5
+
+        ls $MNT | grep testfile.txt
+        cat $MNT/testfile.txt | grep hello
+        cat $MNT/dev/cpu
+
+        umount $MNT
+      '';
+      runner = "nixos";
+      nixosConfig.boot.kernelModules = [ "fuse" ];
+    };
   };
 }


### PR DESCRIPTION
Giving users the option to choose how they want to run the test (bash script or nixos VM) gives them a lot of flexibility and allows us to test thing we previously couldn't (for example, `prismafs` requiring the `fuse` kernel module to be loaded).

Related: https://github.com/ngi-nix/projects/issues/1210