### PR TITLE
treewide: ngi-nix.github.io/forge -> ngi.nixos.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This software is in active development. Expect backwards incompatible changes.
   **multi-component applications** using
   [module system](https://nix.dev/tutorials/module-system/index.html)
 
-- [Web UI](https://ngi-nix.github.io/forge)
+- [Web UI](https://ngi.nixos.org)
 
 - Easy [self hosting](#self-hosting)
 

--- a/docs/announcements/version-0_1.md
+++ b/docs/announcements/version-0_1.md
@@ -1,7 +1,7 @@
 # NGI Forge 0.1 released
 
 We are excited to announce the initial release of
-[NGI Forge](https://ngi-nix.github.io/forge/), our new software packaging and
+[NGI Forge](https://ngi.nixos.org/), our new software packaging and
 distribution system for projects supported by the
 [Next Generation Internet (NGI)](https://www.ngi.eu/) initiative via
 [NLnet](https://nlnet.nl/).
@@ -26,7 +26,7 @@ extend support for other languages as we keep on adding more packages.
 Applications support three runtimes: a **shell environment** for CLI and GUI
 programs, **OCI compatible containers**, and **NixOS** for system services.
 
-A nice [Web UI](https://ngi-nix.github.io/forge/) lets users browse available
+A nice [Web UI](https://ngi.nixos.org/) lets users browse available
 NGI software and run it using simple commands.
 
 Recipes can be generated and maintained with AI assistance by following the instructions in the
@@ -49,7 +49,7 @@ Browse [the list of open user stories](https://github.com/orgs/ngi-nix/projects/
 
 ## Try it out
 
-Visit [NGI Forge](https://ngi-nix.github.io/forge/) to browse and test the first
+Visit [NGI Forge](https://ngi.nixos.org/) to browse and test the first
 available applications.
 
 Source code is available on [GitHub](https://github.com/ngi-nix/forge) and any

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,7 +51,7 @@ pygments_style = "sphinx"
 
 exclude_patterns = []
 
-html_baseurl = "https://ngi-nix.github.io/forge/"
+html_baseurl = "https://ngi.nixos.org/"
 
 html_theme = "sphinx_book_theme"
 

--- a/docs/manuals/contributor/how_to/app_recipe.md
+++ b/docs/manuals/contributor/how_to/app_recipe.md
@@ -3,7 +3,7 @@
 ::: {important}
 For the list of all available configuration options for application recipes,
 see the
-[application options reference](https://ngi-nix.github.io/forge/recipe/options?s=apps).
+[application options reference](https://ngi.nixos.org/recipe/options?s=apps).
 :::
 
 Before writing a recipe, spend some time understanding the software:

--- a/docs/manuals/contributor/how_to/package_recipe.md
+++ b/docs/manuals/contributor/how_to/package_recipe.md
@@ -3,7 +3,7 @@
 ::: {important}
 For the list of all available configuration options for package recipes visit
 the
-[package options reference](https://ngi-nix.github.io/forge/recipe/options?s=pkgs).
+[package options reference](https://ngi.nixos.org/recipe/options?s=pkgs).
 :::
 
 Before writing a recipe, please spend some time to understand the software

--- a/docs/manuals/developer/how_to/test.md
+++ b/docs/manuals/developer/how_to/test.md
@@ -48,7 +48,7 @@ test-ui --ui-host 127.0.0.1
 - Run the tests using Forge production instance
 
 ```bash
-env BASE_URL="https://ngi-nix.github.io/forge/" test-ui --ui-host 127.0.0.1
+env BASE_URL=https://ngi.nixos.org test-ui --ui-host 127.0.0.1
 ```
 
 ### Notes

--- a/docs/manuals/user/quick_start.md
+++ b/docs/manuals/user/quick_start.md
@@ -1,6 +1,6 @@
 # Quick start
 
-1. Visit the [NGI Forge web UI](https://ngi-nix.github.io/forge) in your browser.
+1. Visit the [NGI Forge web UI](https://ngi.nixos.org) in your browser.
 2. Browse the list of available applications.
 3. Choose an application and click the **Run** button.
 4. Follow the instructions to launch the application using your preferred runtime:

--- a/flake/develop/devshell.nix
+++ b/flake/develop/devshell.nix
@@ -17,7 +17,7 @@ let
 
       {33}❄️ Welcome to NGI Forge{reset}
 
-      {85}📖 Website: https://ngi-nix.github.io/forge 💬 Chat: #ngipkgs:matrix.org (Matrix){reset}
+      {85}📖 Website: https://ngi.nixos.org 💬 Chat: #ngipkgs:matrix.org (Matrix){reset}
       $(type -p menu &>/dev/null && menu)
 
       {123}Tip:{reset} DEVSHELL_NO_MOTD=1 will disable this welcome message


### PR DESCRIPTION
Refer to the Forge by its current canonical name consistently.

In the case of `how_to/test.md` I’ve also dropped the quotes around the URL and final slash, since they are not needed in this case, in order to keep it as simple as possible.

In other places I’ve respected the choice of adding or not the final slash to the URL, although it makes me wonder if this choice should be settled one way or the other.