### PR TITLE
feat: add recipe overrides file

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -181,6 +181,18 @@
         "type": "github"
       }
     },
+    "overrides": {
+      "flake": false,
+      "locked": {
+        "path": "./overrides.nix",
+        "type": "path"
+      },
+      "original": {
+        "path": "./overrides.nix",
+        "type": "path"
+      },
+      "parent": []
+    },
     "root": {
       "inputs": {
         "devshell": "devshell",
@@ -190,6 +202,7 @@
         "nimi": "nimi",
         "nix-utils": "nix-utils",
         "nixpkgs": "nixpkgs",
+        "overrides": "overrides",
         "treefmt-nix": "treefmt-nix"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,13 @@
       url = "github:ngi-nix/nimi/ngi-patches";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    # Empty by default. Swap this at the CLI to override recipe configuration.
+    # E.g.: nix run --override-input overrides path:./my-overrides.nix -- .#apps.mox.<app-name>
+    overrides = {
+      url = "path:./overrides.nix";
+      flake = false;
+    };
   };
 
   outputs =
@@ -81,6 +88,8 @@
             perSystem =
               { system, ... }:
               {
+                imports = [ (import inputs.overrides) ];
+
                 forge = {
                   repositoryUrl = self.sourceInfo.url or "github:ngi-nix/forge";
                   maintainerLists = [ self.maintainerList ];

--- a/overrides.nix
+++ b/overrides.nix
@@ -1,0 +1,17 @@
+# Swap this file at the CLI to override recipe configuration without editing
+# recipes:
+#
+# Example:
+# nix run --override-input overrides path:./my-overrides.nix -- .#apps.offen.container
+#
+# my-overrides.nix:
+#
+#   { lib, ... }:
+#   {
+#     forge.apps.offen.services.components.offen.process = {
+#       environment.OFFEN_SERVER_PORT = lib.mkForce "3001";
+#       ports = lib.mkForce [ "3001:3001" ];
+#     };
+#   }
+{
+}


### PR DESCRIPTION
The idea of passing custom recipe configuration without modifying actual recipes.

1. Create `./my-overrides.nix` file:

```nix
{ lib, ... }:

let
  port = "9999";
in
{
  forge.apps.offen.services.components.offen.process = {
    environment.OFFEN_SERVER_PORT = lib.mkForce port;
    ports = lib.mkForce [ "${port}:${port}" ];
  };
}
```

2. Run offen on custom port
```
nix run --override-input overrides path:./my-overrides.nix -- github:ngi-nix/forge/recipe-overrides-file#apps.offen.container
```

3. Open the app at custom port 9999 http://localhost:9999/ .

What do you think ?