### PR TITLE
feat: display data-items as string from their content 

### DIFF
--- a/forge/modules/apps/data-item.nix
+++ b/forge/modules/apps/data-item.nix
@@ -31,6 +31,7 @@
           isBinary = lib.elem true (map (ext: lib.hasSuffix ext config.path) binaryExts);
         in
         if config.path != null && !isBinary then lib.removeSuffix "\n" (lib.readFile config.path) else "";
+      apply = lib.trim;
       defaultText = lib.literalExpression ''if config.path != null && !isBinary then lib.removeSuffix "\n" (lib.readFile config.path) else ""'';
       description = "Data item content. Will be an empty string for binary files as nix doesn't support reading binary files.";
     };
@@ -39,6 +40,10 @@
       default = pkgs.writeText config.name config.content;
       defaultText = lib.literalExpression "pkgs.writeText config.name config.content";
       description = "Data item absolute path.";
+    };
+    __toString = lib.mkOption {
+      type = lib.types.functionTo lib.types.str;
+      default = self: toString self.content;
     };
   };
 }

--- a/recipes/apps/beacondb/recipe.nix
+++ b/recipes/apps/beacondb/recipe.nix
@@ -30,10 +30,8 @@ in
       Example config.toml:
 
       ```
-      ${recipe.data.config.content}
+      ${recipe.data.config}
       ```
-
-
     '';
 
     links = {

--- a/recipes/apps/kaitai-struct/recipe.nix
+++ b/recipes/apps/kaitai-struct/recipe.nix
@@ -53,7 +53,7 @@ in
       #### Quick Start
 
       ```yaml
-      ${app.data.exampleKsy.content}
+      ${app.data.exampleKsy}
       ```
 
       Consider the simple `.ksy` format description above, which describes the header of a GIF image file.
@@ -86,7 +86,7 @@ in
       This shell environment provides python with `kaitaistruct` python package pre-installed.
 
       ```bash
-      ${lib.trim app.data.testInstructions.content}
+      ${app.data.testInstructions}
       ```
 
       This example shows only a very limited subset of what Kaitai Struct can do. Please refer to the [documentation](${config.apps.kaitai-struct.links.docs}) and try the online [ide](https://ide.kaitai.io), which has many examples.

--- a/recipes/apps/typst/recipe.nix
+++ b/recipes/apps/typst/recipe.nix
@@ -32,7 +32,7 @@ in
       A sample document is bundled for a quick first try
 
       ```
-      ${recipe.data.sampleDoc.content}
+      ${recipe.data.sampleDoc}
       ```
 
       Compile the sample document to PDF

--- a/recipes/apps/vacask/recipe.nix
+++ b/recipes/apps/vacask/recipe.nix
@@ -25,10 +25,10 @@ in
 
       #### Basic Usage
 
-      For testing, download one of the [upstream test files](https://codeberg.org/arpadbuermen/VACASK/src/commit/${app.data.testCommit.content}/test). For example:
+      For testing, download one of the [upstream test files](https://codeberg.org/arpadbuermen/VACASK/src/commit/${app.data.testCommit}/test). For example:
 
       ```bash
-      wget https://codeberg.org/arpadbuermen/VACASK/raw/commit/${app.data.testCommit.content}/test/${app.data.testOp.name}
+      wget https://codeberg.org/arpadbuermen/VACASK/raw/commit/${app.data.testCommit}/test/${app.data.testOp.name}
       ```
 
       Afterwards, run the simulation on the netlist file you downloaded:

--- a/recipes/apps/zenroom/recipe.nix
+++ b/recipes/apps/zenroom/recipe.nix
@@ -32,7 +32,7 @@ in
       First, write the following script into a local file (e.g. `${app.data.arrayGenerator.name}`):
 
       ```
-      ${app.data.arrayGenerator.content}
+      ${app.data.arrayGenerator}
       ```
 
       Then, [enter the Nix shell](app/zenroom#run-shell) and execute the script:


### PR DESCRIPTION
Because interpolating the content is easier than having to explicitly specify it each time.