### PR TITLE
fix(ui): handle light and dark mode for inline code blocks

### DIFF
--- a/ui/src/css/main.css
+++ b/ui/src/css/main.css
@@ -36,12 +36,8 @@ body {
   overflow-x: auto;
 }
 
-.markdown-content code {
-  color: #f8f9fa;
-  background-color: transparent;
-}
-
 .markdown-content pre code {
+  background-color: transparent;
   display: block;
   color: #f8f9fa;
   font-family: "Courier New", Courier, monospace;
@@ -49,15 +45,7 @@ body {
   line-height: 1.5;
 }
 
-.markdown-content ul code {
-  background-color: #2d2d2d;
-  color: #f8f9fa;
-  padding: 0.2em 0.4em;
-  border-radius: 0.25rem;
-  font-size: 0.9em;
-}
-
-.markdown-content p code {
+.markdown-content code {
   background-color: #2d2d2d;
   color: #f8f9fa;
   padding: 0.2em 0.4em;


### PR DESCRIPTION
- Closes: https://github.com/ngi-nix/forge/issues/969

check the ui first on `prismafs`, inline code block doesn't have a background like the others, if its not intended to be this way, I will add a background to it
