### PR TITLE
fix(ui): prevent '__toString' option from showing in the options browser

### DIFF
--- a/forge/modules/apps/data-item.nix
+++ b/forge/modules/apps/data-item.nix
@@ -44,6 +44,8 @@
     __toString = lib.mkOption {
       type = lib.types.functionTo lib.types.str;
       default = self: toString self.content;
+      internal = true;
+      readOnly = true;
     };
   };
 }


### PR DESCRIPTION
Prevent `apps.<name>.data.<name>.__toString` from showing in the options
browser in UI.
